### PR TITLE
Fix module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module edi9999/path-extractor
+module github.com/edi9999/path-extractor
 
 go 1.15


### PR DESCRIPTION
Without this fix, `go get github.com/edi9999/path-extractor` gives an error:

```
go: github.com/edi9999/path-extractor@v1.0.1: parsing go.mod:
        module declares its path as: edi9999/path-extractor
                but was required as: github.com/edi9999/path-extractor
```