### PR TITLE
Fix typo in installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ bind '"CC": "| pe | fzf | read filename; [ ! -z $filename ] && echo -n $filename
 # Installation
 
 ```sh
-go install github.com/edi9999/path-extractor/path-extractor@latest
+go install github.com/edi9999/path-extractor@latest
 # sudo mv "$(which path-extractor)" /usr/bin/pe
 ```
 


### PR DESCRIPTION
This commit fixes a typo in the installation command in README.md.

Running the command as given in the current version of `README.md` results in an error:
```
$ go install github.com/edi9999/path-extractor/path-extractor@latest
go: github.com/edi9999/path-extractor/path-extractor@latest: module github.com/edi9999/path-extractor@latest found (v1.0.2), but does not contain package github.com/edi9999/path-extractor/path-extractor
```